### PR TITLE
Allow specifying bind address for HTTP server

### DIFF
--- a/config/private.json.example
+++ b/config/private.json.example
@@ -38,6 +38,7 @@
 		"debug": true
 	},
 	"http": {
+		"host": "*",
 		"port": 8080
 	}
 }

--- a/lg.js
+++ b/lg.js
@@ -62,6 +62,7 @@ cvalid('private.json->logs->requests->http',      config.logs.requests.http,    
 cvalid('private.json->logs->requests->websocket', config.logs.requests.websocket,  'bool'  );
 cvalid('private.json->logs->use_x_forwarded_for', config.logs.use_x_forwarded_for, 'bool'  );
 cvalid('private.json->http',                      config.http,                     'object');
+cvalid('private.json->http->host',                config.http.host,                'string');
 cvalid('private.json->http->port',                config.http.port,                'uint'  );
 cvalid('private.json->logs->debug',               config.logs.debug,               'bool'  );
 cvalid('private.json->limiter',                   config.limiter,                  'object');
@@ -439,7 +440,11 @@ io.on('connection', function(socket) {
 
 app.use(express.static('static'));
 
-server.listen(Number(process.env.PORT) || Number(config.http.port) || 3000);
+if (process.env.HOST || config.http.host && (process.env.HOST || config.http.host) != "*") {
+    server.listen(Number(process.env.PORT) || Number(config.http.port) || 3000, process.env.HOST || config.http.host);
+} else {
+    server.listen(Number(process.env.PORT) || Number(config.http.port) || 3000);
+}
 
 process.on('SIGINT', function () {
 	if (shutdown || !(execqueue.length() + execqueue.running())) {


### PR DESCRIPTION
When running intrace behind a reverse proxy, it is preferable not to expose it to the outside directly.
This commit adds a configuration option (and accompanying entry in the example config) to set the bind address of intrace's HTTP server.

`"host": "*"` can be used to keep Node.JS's default behaviour ("the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise").